### PR TITLE
Refactor data repositories with data sources and interceptors

### DIFF
--- a/data/src/main/java/com/kwonps/data/common/dispatcher/DispatcherProvider.kt
+++ b/data/src/main/java/com/kwonps/data/common/dispatcher/DispatcherProvider.kt
@@ -1,0 +1,21 @@
+package com.kwonps.data.common.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+
+/**
+ * Standardized coroutine dispatcher provider so repositories can be tested with
+ * deterministic schedulers.
+ */
+interface DispatcherProvider {
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+    val mainImmediate: CoroutineDispatcher
+}
+
+class DefaultDispatcherProvider @Inject constructor() : DispatcherProvider {
+    override val io: CoroutineDispatcher = Dispatchers.IO
+    override val default: CoroutineDispatcher = Dispatchers.Default
+    override val mainImmediate: CoroutineDispatcher = Dispatchers.Main.immediate
+}

--- a/data/src/main/java/com/kwonps/data/common/interceptor/FlowCallDecorator.kt
+++ b/data/src/main/java/com/kwonps/data/common/interceptor/FlowCallDecorator.kt
@@ -1,0 +1,42 @@
+package com.kwonps.data.common.interceptor
+
+import com.kwonps.data.common.dispatcher.DispatcherProvider
+import com.kwonps.data.common.logger.RepositoryLogger
+import com.kwonps.domain.model.ApiResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.retryWhen
+import javax.inject.Inject
+
+class FlowCallDecorator @Inject constructor(
+    private val logger: RepositoryLogger,
+    private val retryPolicy: RetryPolicy,
+    private val dispatcherProvider: DispatcherProvider
+) {
+    fun <T> asResultFlow(
+        operationName: String,
+        block: suspend () -> ApiResult<T>
+    ): Flow<ApiResult<T>> = flow {
+        logger.logStart(operationName)
+        emit(block())
+    }
+        .retryWhen { cause, attempt ->
+            val shouldRetry = retryPolicy.shouldRetry(cause, attempt)
+            if (shouldRetry) {
+                logger.logRetry(operationName, cause, attempt)
+                retryPolicy.waitBeforeRetry(attempt)
+            } else {
+                logger.logFailure(operationName, cause)
+            }
+            shouldRetry
+        }
+        .onEach { result -> logger.logCompletion(operationName, result) }
+        .catch { cause ->
+            logger.logFailure(operationName, cause)
+            emit(ApiResult.Exception(cause))
+        }
+        .flowOn(dispatcherProvider.io)
+}

--- a/data/src/main/java/com/kwonps/data/common/interceptor/RetryPolicy.kt
+++ b/data/src/main/java/com/kwonps/data/common/interceptor/RetryPolicy.kt
@@ -1,0 +1,21 @@
+package com.kwonps.data.common.interceptor
+
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+
+class RetryPolicy @Inject constructor(
+    private val maxRetries: Long = DEFAULT_MAX_RETRIES,
+    private val delayMillis: Long = DEFAULT_RETRY_DELAY_MILLIS
+) {
+    fun shouldRetry(cause: Throwable, attempt: Long): Boolean =
+        attempt < maxRetries
+
+    suspend fun waitBeforeRetry(attempt: Long) {
+        delay(delayMillis * (attempt + 1))
+    }
+
+    companion object {
+        const val DEFAULT_MAX_RETRIES = 1L
+        const val DEFAULT_RETRY_DELAY_MILLIS = 200L
+    }
+}

--- a/data/src/main/java/com/kwonps/data/common/logger/RepositoryLogger.kt
+++ b/data/src/main/java/com/kwonps/data/common/logger/RepositoryLogger.kt
@@ -1,0 +1,27 @@
+package com.kwonps.data.common.logger
+
+import android.util.Log
+import com.kwonps.domain.model.ApiResult
+import javax.inject.Inject
+
+class RepositoryLogger @Inject constructor() {
+    fun logStart(operationName: String) {
+        Log.d(TAG, "Starting $operationName")
+    }
+
+    fun logRetry(operationName: String, cause: Throwable, attempt: Long) {
+        Log.w(TAG, "Retrying $operationName after error: ${cause.message}, attempt=${attempt + 1}")
+    }
+
+    fun logFailure(operationName: String, cause: Throwable) {
+        Log.e(TAG, "Failed $operationName: ${cause.message}", cause)
+    }
+
+    fun logCompletion(operationName: String, result: ApiResult<*>) {
+        Log.d(TAG, "Completed $operationName with result=$result")
+    }
+
+    companion object {
+        private const val TAG = "Repository"
+    }
+}

--- a/data/src/main/java/com/kwonps/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/kwonps/data/di/RepositoryModule.kt
@@ -1,7 +1,15 @@
 package com.kwonps.data.di
 
 import android.content.Context
+import com.kwonps.data.common.dispatcher.DefaultDispatcherProvider
+import com.kwonps.data.common.dispatcher.DispatcherProvider
+import com.kwonps.data.common.interceptor.FlowCallDecorator
+import com.kwonps.data.common.interceptor.RetryPolicy
+import com.kwonps.data.common.logger.RepositoryLogger
 import com.kwonps.data.internal.DatabaseHelper
+import com.kwonps.data.mapper.DirectPaymentMapper
+import com.kwonps.data.mapper.PaymentHistoryMapper
+import com.kwonps.data.mapper.UserMapper
 import com.kwonps.data.remote.RetrofitBuilder
 import com.kwonps.data.repositoryImpl.BluetoothCardReaderRepositoryImpl
 import com.kwonps.data.repositoryImpl.DeviceRepositoryImpl
@@ -10,6 +18,10 @@ import com.kwonps.data.repositoryImpl.OfflinePaymentRepositoryImpl
 import com.kwonps.data.repositoryImpl.PaymentHistoryRepositoryImpl
 import com.kwonps.data.repositoryImpl.UsbCardReaderRepositoryImpl
 import com.kwonps.data.repositoryImpl.UserRepositoryImpl
+import com.kwonps.data.source.payment.DirectPaymentRemoteDataSource
+import com.kwonps.data.source.payment.PaymentHistoryRemoteDataSource
+import com.kwonps.data.source.user.UserLocalDataSource
+import com.kwonps.data.source.user.UserRemoteDataSource
 import com.kwonps.domain.model.cardreader.CardReaderData
 import com.kwonps.domain.model.cardreader.CardReaderStatus
 import com.kwonps.domain.repository.CardReaderCommunicateRepository
@@ -37,13 +49,67 @@ object RepositoryModule {
 
     @Provides
     @ViewModelScoped
-    fun provideUserRepository(
-        @ApplicationContext context: Context
-    ): UserRepository = UserRepositoryImpl(
+    fun provideDispatcherProvider(): DispatcherProvider = DefaultDispatcherProvider()
+
+    @Provides
+    @ViewModelScoped
+    fun provideRepositoryLogger(): RepositoryLogger = RepositoryLogger()
+
+    @Provides
+    @ViewModelScoped
+    fun provideRetryPolicy(): RetryPolicy = RetryPolicy()
+
+    @Provides
+    @ViewModelScoped
+    fun provideFlowCallDecorator(
+        repositoryLogger: RepositoryLogger,
+        retryPolicy: RetryPolicy,
+        dispatcherProvider: DispatcherProvider
+    ): FlowCallDecorator = FlowCallDecorator(repositoryLogger, retryPolicy, dispatcherProvider)
+
+    @Provides
+    @ViewModelScoped
+    fun providePaymentHistoryMapper(): PaymentHistoryMapper = PaymentHistoryMapper()
+
+    @Provides
+    @ViewModelScoped
+    fun provideDirectPaymentMapper(): DirectPaymentMapper = DirectPaymentMapper()
+
+    @Provides
+    @ViewModelScoped
+    fun provideUserMapper(): UserMapper = UserMapper()
+
+    @Provides
+    @ViewModelScoped
+    fun provideUserRemoteDataSource(
+        dispatcherProvider: DispatcherProvider
+    ): UserRemoteDataSource = UserRemoteDataSource(
         apiService = RetrofitBuilder.getTmsAPIService(SVC_TMS_URL),
-        userInformationDao = DatabaseHelper.getInstance(context).userInformationDao(),
+        dispatcherProvider = dispatcherProvider,
+    )
+
+    @Provides
+    @ViewModelScoped
+    fun provideUserLocalDataSource(
+        @ApplicationContext context: Context
+    ): UserLocalDataSource = UserLocalDataSource(
+        dao = DatabaseHelper.getInstance(context).userInformationDao(),
         sharedPreferences = context.getSharedPreferences(USER_INFORMATION, Context.MODE_PRIVATE),
-        key = USER_INFORMATION
+        preferenceKey = USER_INFORMATION
+    )
+
+    @Provides
+    @ViewModelScoped
+    fun provideUserRepository(
+        userRemoteDataSource: UserRemoteDataSource,
+        userLocalDataSource: UserLocalDataSource,
+        userMapper: UserMapper,
+        flowCallDecorator: FlowCallDecorator,
+    ): UserRepository = UserRepositoryImpl(
+        remoteDataSource = userRemoteDataSource,
+        localDataSource = userLocalDataSource,
+        mapper = userMapper,
+        flowCallDecorator = flowCallDecorator,
     )
 
     @Provides
@@ -52,7 +118,7 @@ object RepositoryModule {
         fetchConnectedUserInfo: FetchConnectedUserInfo
     ): OfflinePaymentRepository = OfflinePaymentRepositoryImpl(
         apiService = RetrofitBuilder.getTmsAPIService(SVC_TMS_URL),
-        token = fetchConnectedUserInfo()?.key ?: ""
+        token = fetchConnectedUserInfo()?.key ?: "",
     )
 
     @Provides
@@ -63,20 +129,50 @@ object RepositoryModule {
 
     @Provides
     @ViewModelScoped
-    fun provideDirectPaymentRepository(
+    fun provideDirectPaymentRemoteDataSource(
+        dispatcherProvider: DispatcherProvider,
         fetchConnectedUserInfo: FetchConnectedUserInfo
-    ): DirectPaymentRepository = DirectPaymentRepositoryImpl(
+    ): DirectPaymentRemoteDataSource = DirectPaymentRemoteDataSource(
         apiService = RetrofitBuilder.getPayAPIService(SVC_API_URL),
-        payKey = fetchConnectedUserInfo()?.payKey ?: ""
+        payKey = fetchConnectedUserInfo()?.payKey ?: "",
+        dispatcherProvider = dispatcherProvider,
+    )
+
+    @Provides
+    @ViewModelScoped
+    fun provideDirectPaymentRepository(
+        remoteDataSource: DirectPaymentRemoteDataSource,
+        directPaymentMapper: DirectPaymentMapper,
+        flowCallDecorator: FlowCallDecorator
+    ): DirectPaymentRepository = DirectPaymentRepositoryImpl(
+        remoteDataSource = remoteDataSource,
+        mapper = directPaymentMapper,
+        flowCallDecorator = flowCallDecorator,
+    )
+
+    @Provides
+    @ViewModelScoped
+    fun providePaymentHistoryRemoteDataSource(
+        dispatcherProvider: DispatcherProvider,
+        fetchConnectedUserInfo: FetchConnectedUserInfo,
+        paymentHistoryMapper: PaymentHistoryMapper,
+    ): PaymentHistoryRemoteDataSource = PaymentHistoryRemoteDataSource(
+        apiService = RetrofitBuilder.getTmsAPIService(SVC_TMS_URL),
+        token = fetchConnectedUserInfo()?.key ?: "",
+        dispatcherProvider = dispatcherProvider,
+        mapper = paymentHistoryMapper,
     )
 
     @Provides
     @ViewModelScoped
     fun providePaymentHistoryRepository(
-        fetchConnectedUserInfo: FetchConnectedUserInfo
+        paymentHistoryRemoteDataSource: PaymentHistoryRemoteDataSource,
+        paymentHistoryMapper: PaymentHistoryMapper,
+        flowCallDecorator: FlowCallDecorator,
     ): PaymentHistoryRepository = PaymentHistoryRepositoryImpl(
-        apiService = RetrofitBuilder.getTmsAPIService(SVC_TMS_URL),
-        token = fetchConnectedUserInfo()?.key ?: ""
+        remoteDataSource = paymentHistoryRemoteDataSource,
+        mapper = paymentHistoryMapper,
+        flowCallDecorator = flowCallDecorator,
     )
 
     @Provides
@@ -97,7 +193,7 @@ object RepositoryModule {
             override fun sendData(byteArray: ByteArray, isPrint: Boolean) {}
         }
 
-        return when(fetchConnectedDeviceInfo.getCurrentCardReaderData()) {
+        return when (fetchConnectedDeviceInfo.getCurrentCardReaderData()) {
             is CardReaderData.Bluetooth -> BluetoothCardReaderRepositoryImpl(context)
             is CardReaderData.Usb -> UsbCardReaderRepositoryImpl(context)
             is CardReaderData.Init -> emptyDeviceCommunicateManager

--- a/data/src/main/java/com/kwonps/data/mapper/DirectPaymentMapper.kt
+++ b/data/src/main/java/com/kwonps/data/mapper/DirectPaymentMapper.kt
@@ -1,0 +1,118 @@
+package com.kwonps.data.mapper
+
+import com.kwonps.data.remote.dto.request.RequestDirectPayment
+import com.kwonps.data.remote.dto.response.ResponseDirectPayment
+import com.kwonps.domain.model.payment.AmountData
+import com.kwonps.domain.model.payment.DirectPaymentData
+import com.kwonps.domain.model.payment.Installment
+import com.kwonps.domain.model.payment.PaymentDetailData
+import javax.inject.Inject
+
+class DirectPaymentMapper @Inject constructor() {
+    fun toApproveRequest(directPaymentData: DirectPaymentData.Approve): RequestDirectPayment.DirectPayment {
+        val directPaymentPayCard = RequestDirectPayment.DirectPaymentPayCard(
+            number = directPaymentData.cardNumber,
+            expiry = directPaymentData.expiry,
+            installment = directPaymentData.installment,
+            cvv = null,
+            cardId = null,
+            last4 = null,
+            issuer = null,
+            cardType = null
+        )
+
+        val directPaymentPayProduct = RequestDirectPayment.DirectPaymentPayProduct(
+            name = directPaymentData.productName,
+            qty = null,
+            price = null,
+            desc = null
+        )
+
+        val directPaymentPayMetadata = RequestDirectPayment.DirectPaymentPayMetadata(
+            cardAuth = directPaymentData.cardAuth,
+            authPw = directPaymentData.authPw,
+            authDob = directPaymentData.authDob
+        )
+
+        return RequestDirectPayment.DirectPayment(
+            RequestDirectPayment.DirectPaymentPay(
+                trxType = "ONTR",
+                trackId = directPaymentData.trackId,
+                amount = directPaymentData.totalAmount.toString(),
+                payerName = directPaymentData.payerName,
+                payerTel = directPaymentData.payerTel,
+                card = directPaymentPayCard,
+                product = directPaymentPayProduct,
+                payerEmail = null,
+                fillerAmt = null,
+                udf1 = null,
+                udf2 = null,
+                metadata = directPaymentPayMetadata,
+                trxId = null,
+                authCd = null,
+                settle = null,
+            )
+        )
+    }
+
+    fun toCancelRequest(directPaymentData: DirectPaymentData.Cancel) = RequestDirectPayment.DirectCancelPayment(
+        RequestDirectPayment.DirectCancelPaymentRefund(
+            trxType = "ONTR",
+            trackId = directPaymentData.trackId,
+            amount = directPaymentData.totalAmount.toString(),
+            rootTrxId = directPaymentData.rootTrxId,
+            rootTrxDay = null,
+            udf1 = null,
+            udf2 = null,
+            rootTrackId = null,
+            trxId = null,
+            authCd = null,
+            tmnId = null
+        )
+    )
+
+    fun toPaymentDetail(response: ResponseDirectPayment.DirectPayment) = PaymentDetailData(
+        amount = AmountData(totalAmount = response.pay!!.amount),
+        installment = Installment(response.pay.card.installment.toString()),
+        approval = PaymentDetailData.ApprovalInfo(
+            authCode = response.pay.authCd!!,
+            authDate = response.result.create
+        ),
+        tracking = PaymentDetailData.TrackingInfo(
+            trackId = response.pay.trackId,
+            trxId = response.pay.trxId,
+            trxResult = response.pay.trxType,
+        ),
+        card = PaymentDetailData.CardInfo(
+            cardNumber = "${response.pay.card.bin}${"**********"}${response.pay.card.last4}",
+            cardType = null,
+            issuerName = response.pay.card.issuer,
+            purchaseName = response.pay.product.name,
+        ),
+        remainAmount = null,
+    )
+
+    fun toCancelledPaymentDetail(
+        response: ResponseDirectPayment.DirectCancelPayment,
+        directPaymentData: DirectPaymentData.Cancel
+    ) = PaymentDetailData(
+        amount = AmountData(totalAmount = response.refund!!.amount.toInt()),
+        installment = Installment(directPaymentData.installment),
+        approval = PaymentDetailData.ApprovalInfo(
+            authCode = response.refund!!.authCd!!,
+            authDate = response.result.create
+        ),
+        tracking = PaymentDetailData.TrackingInfo(
+            trackId = response.refund!!.trackId,
+            trxId = response.refund!!.trxId!!,
+            trxResult = response.refund.trxType
+        ),
+        card = PaymentDetailData.CardInfo(
+            cardNumber = directPaymentData.cardNumber,
+            cardType = null,
+            issuerName = null,
+            purchaseName = null
+        ),
+        remainAmount = null,
+    )
+}

--- a/data/src/main/java/com/kwonps/data/mapper/PaymentHistoryMapper.kt
+++ b/data/src/main/java/com/kwonps/data/mapper/PaymentHistoryMapper.kt
@@ -1,0 +1,80 @@
+package com.kwonps.data.mapper
+
+import com.kwonps.data.remote.dto.request.RequestPaymentHistory
+import com.kwonps.data.remote.dto.response.ResponsePaymentHistory
+import com.kwonps.domain.model.paymentHistory.DailyAndMonthlyPaymentStatisticData
+import com.kwonps.domain.model.paymentHistory.PaymentHistoryData
+import com.kwonps.domain.model.paymentHistory.PaymentStatisticData
+import com.kwonps.domain.model.paymentHistory.PeriodData
+import javax.inject.Inject
+
+class PaymentHistoryMapper @Inject constructor() {
+    fun toListRequest(periodData: PeriodData): RequestPaymentHistory.GetPaymentList =
+        RequestPaymentHistory.GetPaymentList(
+            startDay = periodData.first,
+            endDay = periodData.last,
+            lastRegTime = null,
+            lastRegDay = null
+        )
+
+    fun toStatisticRequest(periodData: PeriodData): RequestPaymentHistory.GetPaymentStatistics =
+        RequestPaymentHistory.GetPaymentStatistics(
+            startDay = periodData.first,
+            endDay = periodData.last
+        )
+
+    fun toDirectPaymentCheck(trxId: String) = RequestPaymentHistory.DirectPaymentCheck(trxId)
+
+    fun toDomainList(response: List<ResponsePaymentHistory.PaymentContents>): List<PaymentHistoryData> =
+        response.map {
+            PaymentHistoryData(
+                rfdTime = it.rfdTime,
+                amount = it.amount,
+                van = it.van,
+                vanTrxId = it.vanTrxId,
+                authCd = it.authCd,
+                tmnId = it.tmnId,
+                trackId = it.trackId,
+                bin = it.bin,
+                cardType = it.cardType,
+                trxId = it.trxId,
+                issuer = it.issuer,
+                regDay = it.regDay,
+                resultMsg = it.resultMsg,
+                number = it.number,
+                trxResult = it.trxResult,
+                regTime = it.regTime,
+                vanId = it.vanId,
+                _idx = it._idx,
+                installment = it.installment,
+                rfdDay = it.rfdDay,
+                mchtId = it.mchtId,
+                brand = it.brand,
+                rfdId = it.rfdId,
+            )
+        }
+
+    fun toStatistic(response: ResponsePaymentHistory.GetPaymentStatistics) = PaymentStatisticData(
+        approveAmount = response.payAmt,
+        approveCount = response.payCnt,
+        cancelAmount = response.rfdAmt,
+        cancelCount = response.rfdCnt
+    )
+
+    fun toDailyAndMonthlyStatistic(
+        response: ResponsePaymentHistory.GetSummaryPaymentStatistics
+    ) = DailyAndMonthlyPaymentStatisticData(
+        today = PaymentStatisticData(
+            approveAmount = response.dayPay,
+            approveCount = response.dayPayCnt,
+            cancelAmount = response.dayRef,
+            cancelCount = response.dayRefCnt
+        ),
+        month = PaymentStatisticData(
+            approveAmount = response.monthPay,
+            approveCount = response.monthPayCnt,
+            cancelAmount = response.monthRef,
+            cancelCount = response.monthRefCnt
+        )
+    )
+}

--- a/data/src/main/java/com/kwonps/data/mapper/UserMapper.kt
+++ b/data/src/main/java/com/kwonps/data/mapper/UserMapper.kt
@@ -1,0 +1,73 @@
+package com.kwonps.data.mapper
+
+import com.kwonps.data.internal.entity.UserEntity
+import com.kwonps.data.remote.dto.request.RequestUser
+import com.kwonps.data.remote.dto.response.ResponseUser
+import com.kwonps.domain.model.user.UserData
+import com.kwonps.domain.model.user.UserDetailData
+import javax.inject.Inject
+
+class UserMapper @Inject constructor() {
+    fun toLoginRequest(loginInfo: UserData) = RequestUser.Login(
+        tmnId = loginInfo.tmnId,
+        serial = loginInfo.serial,
+        merchantId = loginInfo.mchtId,
+        appId = null,
+        version = null,
+        telNo = null
+    )
+
+    fun toDomainUserDetail(response: ResponseUser.Login, loginInfo: UserData) = UserDetailData(
+        tmnId = response.tmnId,
+        serial = loginInfo.serial,
+        mchtId = loginInfo.mchtId,
+        mchtName = response.name,
+        telNo = response.telNo,
+        ceoName = response.ceoName,
+        address = response.addr,
+        identity = response.identity,
+        semiAuth = response.semiAuth,
+        appDirect = response.appDirect,
+        key = response.key,
+        vat = response.vat,
+        apiMaxInstall = response.apiMaxInstall,
+        payKey = response.payKey,
+        van = response.van,
+    )
+
+    fun toEntity(userDetailData: UserDetailData) = UserEntity(
+        tmnId = userDetailData.tmnId,
+        serial = userDetailData.serial,
+        mchtId = userDetailData.mchtId,
+        mchtName = userDetailData.mchtName,
+        telNo = userDetailData.telNo,
+        ceoName = userDetailData.ceoName,
+        address = userDetailData.address,
+        identity = userDetailData.identity,
+        semiAuth = userDetailData.semiAuth,
+        appDirect = userDetailData.appDirect,
+        key = userDetailData.key,
+        vat = userDetailData.vat,
+        apiMaxInstall = userDetailData.apiMaxInstall,
+        payKey = userDetailData.payKey,
+        van = userDetailData.van,
+    )
+
+    fun toDomain(userEntity: UserEntity) = UserDetailData(
+        tmnId = userEntity.tmnId,
+        serial = userEntity.serial,
+        mchtId = userEntity.mchtId,
+        mchtName = userEntity.mchtName,
+        telNo = userEntity.telNo,
+        ceoName = userEntity.ceoName,
+        address = userEntity.address,
+        identity = userEntity.identity,
+        semiAuth = userEntity.semiAuth,
+        appDirect = userEntity.appDirect,
+        key = userEntity.key,
+        vat = userEntity.vat,
+        apiMaxInstall = userEntity.apiMaxInstall,
+        payKey = userEntity.payKey,
+        van = userEntity.van,
+    )
+}

--- a/data/src/main/java/com/kwonps/data/repositoryImpl/DirectPaymentRepositoryImpl.kt
+++ b/data/src/main/java/com/kwonps/data/repositoryImpl/DirectPaymentRepositoryImpl.kt
@@ -1,159 +1,51 @@
 package com.kwonps.data.repositoryImpl
 
-import com.kwonps.data.remote.apiservice.PayAPIService
-import com.kwonps.data.remote.dto.request.RequestDirectPayment
-import com.kwonps.data.remote.dto.response.ResponseDirectPayment
+import com.kwonps.data.common.interceptor.FlowCallDecorator
+import com.kwonps.data.mapper.DirectPaymentMapper
 import com.kwonps.data.remote.handleApiResultDetail
+import com.kwonps.data.source.payment.DirectPaymentRemoteDataSource
 import com.kwonps.domain.model.ApiResult
-import com.kwonps.domain.model.payment.AmountData
 import com.kwonps.domain.model.payment.DirectPaymentData
-import com.kwonps.domain.model.payment.Installment
 import com.kwonps.domain.model.payment.PaymentDetailData
 import com.kwonps.domain.repository.DirectPaymentRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
+/**
+ * Direct payment repository backed by the VAN endpoint. Cache strategy: none; each
+ * transaction is processed remotely and reflected immediately. Synchronization uses the
+ * FlowCallDecorator to enforce retry and logging.
+ */
 class DirectPaymentRepositoryImpl @Inject constructor(
-    private val apiService: PayAPIService,
-    private val payKey: String
-): DirectPaymentRepository {
+    private val remoteDataSource: DirectPaymentRemoteDataSource,
+    private val mapper: DirectPaymentMapper,
+    private val flowCallDecorator: FlowCallDecorator
+) : DirectPaymentRepository {
     override suspend fun approve(
         directPaymentInfo: DirectPaymentData.Approve
-    ): Flow<ApiResult<PaymentDetailData>> = flow {
-        val response = apiService.sendDirectPayment(
-            payKey,
-            directPaymentInfo.toRequestDirectPayment()
-        ).handleApiResultDetail {
-            if (it.result.resultCd == "0000") {
-                ApiResult.Success(it.toPaymentDetailInfo())
-            } else {
-                ApiResult.Error(it.result.advanceMsg)
-            }
+    ): Flow<ApiResult<PaymentDetailData>> =
+        flowCallDecorator.asResultFlow("directPayment:approve") {
+            remoteDataSource.approve(mapper.toApproveRequest(directPaymentInfo))
+                .handleApiResultDetail { response ->
+                    if (response.result.resultCd == "0000") {
+                        ApiResult.Success(mapper.toPaymentDetail(response))
+                    } else {
+                        ApiResult.Error(response.result.advanceMsg)
+                    }
+                }
         }
-        emit(response)
-    }.catch { e -> emit(ApiResult.Exception(e)) }
 
     override suspend fun cancel(
         directPaymentInfo: DirectPaymentData.Cancel
-    ): Flow<ApiResult<PaymentDetailData>> = flow {
-        val response = apiService.sendDirectRefund(
-            payKey,
-            directPaymentInfo.toRequestDirectCancelPayment()
-        ).handleApiResultDetail {
-            if (it.result.resultCd == "0000") {
-                ApiResult.Success(it.toPaymentDetailInfo(directPaymentInfo))
-            } else {
-                ApiResult.Error(it.result.advanceMsg)
-            }
+    ): Flow<ApiResult<PaymentDetailData>> =
+        flowCallDecorator.asResultFlow("directPayment:cancel") {
+            remoteDataSource.cancel(mapper.toCancelRequest(directPaymentInfo))
+                .handleApiResultDetail { response ->
+                    if (response.result.resultCd == "0000") {
+                        ApiResult.Success(mapper.toCancelledPaymentDetail(response, directPaymentInfo))
+                    } else {
+                        ApiResult.Error(response.result.advanceMsg)
+                    }
+                }
         }
-        emit(response)
-    }.catch { e -> emit(ApiResult.Exception(e)) }
-
-    private fun DirectPaymentData.Approve.toRequestDirectPayment(): RequestDirectPayment.DirectPayment {
-        val directPaymentPayCard = RequestDirectPayment.DirectPaymentPayCard(
-            number = cardNumber,
-            expiry = expiry,
-            installment = installment,
-            cvv = null,
-            cardId = null,
-            last4 = null,
-            issuer = null,
-            cardType = null
-        )
-
-        val directPaymentPayProduct = RequestDirectPayment.DirectPaymentPayProduct(
-            name = productName,
-            qty = null,
-            price = null,
-            desc = null
-        )
-
-        val directPaymentPayMetadata = RequestDirectPayment.DirectPaymentPayMetadata(
-            cardAuth = cardAuth,
-            authPw = authPw,
-            authDob = authDob
-        )
-
-        return RequestDirectPayment.DirectPayment(
-            RequestDirectPayment.DirectPaymentPay(
-                trxType = "ONTR",
-                trackId = trackId,
-                amount = totalAmount.toString(),
-                payerName = payerName,
-                payerTel = payerTel,
-                card = directPaymentPayCard,
-                product = directPaymentPayProduct,
-                payerEmail = null,
-                fillerAmt = null,
-                udf1 = null,
-                udf2 = null,
-                metadata = directPaymentPayMetadata,
-                trxId = null,
-                authCd = null,
-                settle = null,
-            )
-        )
-    }
-
-    private fun DirectPaymentData.Cancel.toRequestDirectCancelPayment() = RequestDirectPayment.DirectCancelPayment(
-        RequestDirectPayment.DirectCancelPaymentRefund(
-            trxType = "ONTR",
-            trackId = trackId,
-            amount = totalAmount.toString(),
-            rootTrxId = rootTrxId,
-            rootTrxDay = null,
-            udf1 = null,
-            udf2 = null,
-            rootTrackId = null,
-            trxId = null,
-            authCd = null,
-            tmnId = null
-        )
-    )
-
-    private fun ResponseDirectPayment.DirectPayment.toPaymentDetailInfo() = PaymentDetailData(
-        amount = AmountData(totalAmount = pay!!.amount),
-        installment = Installment(pay.card.installment.toString()),
-        approval = PaymentDetailData.ApprovalInfo(
-            authCode = pay.authCd!!,
-            authDate = result.create
-        ),
-        tracking = PaymentDetailData.TrackingInfo(
-            trackId = pay.trackId,
-            trxId = pay.trxId,
-            trxResult = pay.trxType,
-        ),
-        card = PaymentDetailData.CardInfo(
-            cardNumber = "${pay.card.bin}${"**********"}${pay.card.last4}",
-            cardType = null,
-            issuerName = pay.card.issuer,
-            purchaseName = pay.product.name,
-        ),
-        remainAmount = null,
-    )
-
-    private fun ResponseDirectPayment.DirectCancelPayment.toPaymentDetailInfo(
-        directPaymentData: DirectPaymentData.Cancel
-    ) = PaymentDetailData(
-        amount = AmountData(totalAmount = refund!!.amount.toInt()),
-        installment = Installment(directPaymentData.installment),
-        approval = PaymentDetailData.ApprovalInfo(
-            authCode = refund!!.authCd!!,
-            authDate = result.create
-        ),
-        tracking = PaymentDetailData.TrackingInfo(
-            trackId = refund!!.trackId,
-            trxId = refund!!.trxId!!,
-            trxResult = refund.trxType
-        ),
-        card = PaymentDetailData.CardInfo(
-            cardNumber = directPaymentData.cardNumber,
-            cardType = null,
-            issuerName = null,
-            purchaseName = null
-        ),
-        remainAmount = null,
-    )
 }

--- a/data/src/main/java/com/kwonps/data/repositoryImpl/PaymentHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/kwonps/data/repositoryImpl/PaymentHistoryRepositoryImpl.kt
@@ -1,111 +1,49 @@
 package com.kwonps.data.repositoryImpl
 
-import com.kwonps.data.remote.dto.request.RequestPaymentHistory
-import com.kwonps.data.remote.DataFormat
-import com.kwonps.data.remote.apiservice.TmsAPIService
-import com.kwonps.data.remote.dto.response.ResponsePaymentHistory
+import com.kwonps.data.common.interceptor.FlowCallDecorator
+import com.kwonps.data.mapper.PaymentHistoryMapper
 import com.kwonps.data.remote.handleApiResult
+import com.kwonps.data.source.payment.PaymentHistoryRemoteDataSource
 import com.kwonps.domain.model.ApiResult
 import com.kwonps.domain.model.paymentHistory.DailyAndMonthlyPaymentStatisticData
 import com.kwonps.domain.model.paymentHistory.PaymentHistoryData
 import com.kwonps.domain.model.paymentHistory.PaymentStatisticData
 import com.kwonps.domain.model.paymentHistory.PeriodData
 import com.kwonps.domain.repository.PaymentHistoryRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
+/**
+ * Remote-first payment history repository. Cache strategy: stateless remote reads only;
+ * synchronization relies on the upstream VAN/TMS server. Common logging and retry
+ * behavior is centralized in [flowCallDecorator].
+ */
 class PaymentHistoryRepositoryImpl @Inject constructor(
-    private val apiService: TmsAPIService,
-    private val token: String
-): PaymentHistoryRepository {
-    override suspend fun searchPaymentList(periodInfo: PeriodData): Flow<ApiResult<List<PaymentHistoryData>>> = flow {
-        val response = apiService.list(
-            token = token,
-            body = DataFormat(periodInfo.toRequestGetPaymentListModel())
-        )
-        emit(response.handleApiResult { it.data.list.toListPaymentDetailInfo() })
-    }
-
-    override suspend fun searchPaymentStatistic(periodInfo: PeriodData): Flow<ApiResult<PaymentStatisticData>> = flow {
-        val response = apiService.statistics(
-            token = token,
-            body = DataFormat(periodInfo.toRequestGetPaymentStatisticsModel())
-        )
-        emit(response.handleApiResult { it.data.toPaymentStatistic() })
-    }
-
-    override suspend fun searchPaymentStatistic(): Flow<ApiResult<DailyAndMonthlyPaymentStatisticData>> = flow {
-        with(apiService.summary(token)) {
-            emit(handleApiResult { it.data.toPaymentStatistic() })
+    private val remoteDataSource: PaymentHistoryRemoteDataSource,
+    private val mapper: PaymentHistoryMapper,
+    private val flowCallDecorator: FlowCallDecorator
+) : PaymentHistoryRepository {
+    override suspend fun searchPaymentList(periodInfo: PeriodData): Flow<ApiResult<List<PaymentHistoryData>>> =
+        flowCallDecorator.asResultFlow("paymentHistory:searchPaymentList") {
+            remoteDataSource.fetchPaymentList(periodInfo)
+                .handleApiResult { mapper.toDomainList(it.data.list) }
         }
-    }
 
-    override suspend fun checkDirectPayment(trxId: String): Flow<ApiResult<Boolean>> = flow {
-        with(apiService.check(token, DataFormat(RequestPaymentHistory.DirectPaymentCheck(trxId)))) {
-            emit(handleApiResult { it.data.trxType == "ONTR" })
+    override suspend fun searchPaymentStatistic(periodInfo: PeriodData): Flow<ApiResult<PaymentStatisticData>> =
+        flowCallDecorator.asResultFlow("paymentHistory:searchPaymentStatistic") {
+            remoteDataSource.fetchPaymentStatistics(periodInfo)
+                .handleApiResult { mapper.toStatistic(it.data) }
         }
-    }
 
-    private fun PeriodData.toRequestGetPaymentListModel() = RequestPaymentHistory.GetPaymentList(
-        startDay = first,
-        endDay = last,
-        lastRegTime = null,
-        lastRegDay = null
-    )
+    override suspend fun searchPaymentStatistic(): Flow<ApiResult<DailyAndMonthlyPaymentStatisticData>> =
+        flowCallDecorator.asResultFlow("paymentHistory:searchPaymentStatisticSummary") {
+            remoteDataSource.fetchSummaryPaymentStatistics()
+                .handleApiResult { mapper.toDailyAndMonthlyStatistic(it.data) }
+        }
 
-    private fun PeriodData.toRequestGetPaymentStatisticsModel() = RequestPaymentHistory.GetPaymentStatistics(
-        startDay = first,
-        endDay = last
-    )
-
-    private fun List<ResponsePaymentHistory.PaymentContents>.toListPaymentDetailInfo() = map {
-        PaymentHistoryData(
-            rfdTime = it.rfdTime,
-            amount = it.amount,
-            van = it.van,
-            vanTrxId = it.vanTrxId,
-            authCd = it.authCd,
-            tmnId = it.tmnId,
-            trackId = it.trackId,
-            bin = it.bin,
-            cardType = it.cardType,
-            trxId = it.trxId,
-            issuer = it.issuer,
-            regDay = it.regDay,
-            resultMsg = it.resultMsg,
-            number = it.number,
-            trxResult = it.trxResult,
-            regTime = it.regTime,
-            vanId = it.vanId,
-            _idx = it._idx,
-            installment = it.installment,
-            rfdDay = it.rfdDay,
-            mchtId = it.mchtId,
-            brand = it.brand,
-            rfdId = it.rfdId,
-        )
-    }
-
-    private fun ResponsePaymentHistory.GetSummaryPaymentStatistics.toPaymentStatistic() = DailyAndMonthlyPaymentStatisticData(
-        today = PaymentStatisticData(
-            approveAmount = dayPay,
-            approveCount = dayPayCnt,
-            cancelAmount = dayRef,
-            cancelCount = dayRefCnt
-        ),
-        month = PaymentStatisticData(
-            approveAmount = monthPay,
-            approveCount = monthPayCnt,
-            cancelAmount = monthRef,
-            cancelCount = monthRefCnt
-        )
-    )
-
-    private fun ResponsePaymentHistory.GetPaymentStatistics.toPaymentStatistic() = PaymentStatisticData(
-        approveAmount = payAmt,
-        approveCount = payCnt,
-        cancelAmount = rfdAmt,
-        cancelCount = rfdCnt
-    )
+    override suspend fun checkDirectPayment(trxId: String): Flow<ApiResult<Boolean>> =
+        flowCallDecorator.asResultFlow("paymentHistory:checkDirectPayment") {
+            remoteDataSource.checkDirectPayment(trxId)
+                .handleApiResult { it.data.trxType == "ONTR" }
+        }
 }

--- a/data/src/main/java/com/kwonps/data/repositoryImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/kwonps/data/repositoryImpl/UserRepositoryImpl.kt
@@ -1,112 +1,50 @@
 package com.kwonps.data.repositoryImpl
 
-import android.content.SharedPreferences
-import com.kwonps.data.remote.dto.request.RequestUser
-import com.kwonps.data.remote.dto.response.ResponseUser
-import com.kwonps.data.internal.dao.UserInformationDAO
-import com.kwonps.data.internal.entity.UserEntity
-import com.kwonps.data.remote.DataFormat
-import com.kwonps.data.remote.apiservice.TmsAPIService
+import com.kwonps.data.common.interceptor.FlowCallDecorator
+import com.kwonps.data.mapper.UserMapper
 import com.kwonps.data.remote.handleApiResult
+import com.kwonps.data.source.user.UserLocalDataSource
+import com.kwonps.data.source.user.UserRemoteDataSource
 import com.kwonps.domain.model.ApiResult
 import com.kwonps.domain.model.user.UserData
 import com.kwonps.domain.model.user.UserDetailData
 import com.kwonps.domain.repository.UserRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
+/**
+ * User repository combining local cache and remote login validation. Cache strategy: the
+ * last login payload is persisted in SharedPreferences and synchronized with the Room
+ * backing store; remote validation remains the source of truth for credentials.
+ */
 class UserRepositoryImpl @Inject constructor(
-    private val apiService: TmsAPIService,
-    private val userInformationDao: UserInformationDAO,
-    private val sharedPreferences: SharedPreferences,
-    private val key: String
-): UserRepository {
-    override fun getCurrentLoginUserInformation(): String? = sharedPreferences.getString(key, null)
+    private val remoteDataSource: UserRemoteDataSource,
+    private val localDataSource: UserLocalDataSource,
+    private val mapper: UserMapper,
+    private val flowCallDecorator: FlowCallDecorator,
+) : UserRepository {
+    override fun getCurrentLoginUserInformation(): String? = localDataSource.getCurrentLoginUserInformation()
 
     override fun setCurrentLoginUserInformation(responseLoginModelString: String) {
-        sharedPreferences.edit().putString(key, responseLoginModelString).apply()
+        localDataSource.setCurrentLoginUserInformation(responseLoginModelString)
     }
 
     override fun insertUserInformation(userInfo: UserDetailData) {
-        userInformationDao.insertUserInformation(userInfo.toUserInformationEntity())
+        localDataSource.insertUserInformation(mapper.toEntity(userInfo))
     }
 
-    override fun getAllUserInformation(): Flow<List<UserDetailData>> = userInformationDao.getAllUserInformation().map { userInformationEntity ->
-        userInformationEntity.map { it.toRequestGetUserInformationModel() }
-    }
+    override fun getAllUserInformation(): Flow<List<UserDetailData>> =
+        localDataSource.getAllUserInformation().map { entityList -> entityList.map(mapper::toDomain) }
 
     override fun deleteUserInformation(tmnId: String) {
-        userInformationDao.deleteUserInformation(tmnId)
+        localDataSource.deleteUserInformation(tmnId)
     }
 
-    override suspend fun validateLoginInfo(loginInfo: UserData): Flow<ApiResult<UserDetailData>> = flow {
-        val response = apiService.key(DataFormat(loginInfo.toRequestGetUserInformationModel()))
-        emit(response.handleApiResult { it.data.toUserInformationEntity(loginInfo) })
-    }.catch { e -> emit(ApiResult.Exception(e)) }
-
-    private fun UserData.toRequestGetUserInformationModel() = RequestUser.Login(
-        tmnId = tmnId,
-        serial = serial,
-        merchantId = mchtId,
-        appId = null,
-        version = null,
-        telNo = null
-    )
-
-    private fun ResponseUser.Login.toUserInformationEntity(loginInfo: UserData) = UserDetailData(
-        tmnId = tmnId,
-        serial = loginInfo.serial,
-        mchtId = loginInfo.mchtId,
-        mchtName = name,
-        telNo = telNo,
-        ceoName = ceoName,
-        address = addr,
-        identity = identity,
-        semiAuth = semiAuth,
-        appDirect = appDirect,
-        key = key,
-        vat = vat,
-        apiMaxInstall = apiMaxInstall,
-        payKey = payKey,
-        van = van,
-    )
-
-    private fun UserDetailData.toUserInformationEntity() = UserEntity(
-        tmnId = tmnId,
-        serial = serial,
-        mchtId = mchtId,
-        mchtName = mchtName,
-        telNo = telNo,
-        ceoName = ceoName,
-        address = address,
-        identity = identity,
-        semiAuth = semiAuth,
-        appDirect = appDirect,
-        key = key,
-        vat = vat,
-        apiMaxInstall = apiMaxInstall,
-        payKey = payKey,
-        van = van
-    )
-
-    private fun UserEntity.toRequestGetUserInformationModel() = UserDetailData(
-        tmnId = tmnId,
-        serial = serial,
-        mchtId = mchtId,
-        mchtName = mchtName,
-        telNo = telNo,
-        ceoName = ceoName,
-        address = address,
-        identity = identity,
-        semiAuth = semiAuth,
-        appDirect = appDirect,
-        key = key,
-        vat = vat,
-        apiMaxInstall = apiMaxInstall,
-        payKey = payKey,
-        van = van
-    )
+    override suspend fun validateLoginInfo(userData: UserData): Flow<ApiResult<UserDetailData>> =
+        flowCallDecorator.asResultFlow("user:validateLoginInfo") {
+            remoteDataSource.validateLogin(mapper.toLoginRequest(userData)).handleApiResult {
+                mapper.toDomainUserDetail(it.data, userData)
+            }
+        }
 }

--- a/data/src/main/java/com/kwonps/data/source/payment/DirectPaymentRemoteDataSource.kt
+++ b/data/src/main/java/com/kwonps/data/source/payment/DirectPaymentRemoteDataSource.kt
@@ -1,0 +1,25 @@
+package com.kwonps.data.source.payment
+
+import com.kwonps.data.common.dispatcher.DispatcherProvider
+import com.kwonps.data.remote.apiservice.PayAPIService
+import com.kwonps.data.remote.dto.request.RequestDirectPayment
+import com.kwonps.data.remote.dto.response.ResponseDirectPayment
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+
+/**
+ * Direct-payment remote source. No local cache is used because VAN approvals must be
+ * consistent with server-side reconciliation.
+ */
+class DirectPaymentRemoteDataSource @Inject constructor(
+    private val apiService: PayAPIService,
+    private val payKey: String,
+    private val dispatcherProvider: DispatcherProvider
+) {
+    suspend fun approve(request: RequestDirectPayment.DirectPayment): Response<ResponseDirectPayment.DirectPayment> =
+        withContext(dispatcherProvider.io) { apiService.sendDirectPayment(payKey, request) }
+
+    suspend fun cancel(request: RequestDirectPayment.DirectCancelPayment): Response<ResponseDirectPayment.DirectCancelPayment> =
+        withContext(dispatcherProvider.io) { apiService.sendDirectRefund(payKey, request) }
+}

--- a/data/src/main/java/com/kwonps/data/source/payment/PaymentHistoryRemoteDataSource.kt
+++ b/data/src/main/java/com/kwonps/data/source/payment/PaymentHistoryRemoteDataSource.kt
@@ -1,0 +1,47 @@
+package com.kwonps.data.source.payment
+
+import com.kwonps.data.common.dispatcher.DispatcherProvider
+import com.kwonps.data.mapper.PaymentHistoryMapper
+import com.kwonps.data.remote.DataFormat
+import com.kwonps.data.remote.apiservice.TmsAPIService
+import com.kwonps.data.remote.dto.response.ResponsePaymentHistory
+import com.kwonps.domain.model.paymentHistory.PeriodData
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+
+/**
+ * Remote-only source for payment history. Cache strategy: none, because history and
+ * statistics must always reflect server state. Synchronization policy: each network call
+ * is executed on the IO dispatcher and retried via FlowCallDecorator.
+ */
+class PaymentHistoryRemoteDataSource @Inject constructor(
+    private val apiService: TmsAPIService,
+    private val token: String,
+    private val dispatcherProvider: DispatcherProvider,
+    private val mapper: PaymentHistoryMapper,
+) {
+    suspend fun fetchPaymentList(periodInfo: PeriodData): Response<ResponsePaymentHistory.GetPaymentList> =
+        withContext(dispatcherProvider.io) {
+            apiService.list(
+                token = token,
+                body = DataFormat(mapper.toListRequest(periodInfo))
+            )
+        }
+
+    suspend fun fetchPaymentStatistics(periodInfo: PeriodData): Response<ResponsePaymentHistory.GetPaymentStatistics> =
+        withContext(dispatcherProvider.io) {
+            apiService.statistics(
+                token = token,
+                body = DataFormat(mapper.toStatisticRequest(periodInfo))
+            )
+        }
+
+    suspend fun fetchSummaryPaymentStatistics(): Response<ResponsePaymentHistory.GetSummaryPaymentStatistics> =
+        withContext(dispatcherProvider.io) { apiService.summary(token) }
+
+    suspend fun checkDirectPayment(trxId: String): Response<ResponsePaymentHistory.DirectPaymentCheck> =
+        withContext(dispatcherProvider.io) {
+            apiService.check(token, DataFormat(mapper.toDirectPaymentCheck(trxId)))
+        }
+}

--- a/data/src/main/java/com/kwonps/data/source/user/UserLocalDataSource.kt
+++ b/data/src/main/java/com/kwonps/data/source/user/UserLocalDataSource.kt
@@ -1,0 +1,35 @@
+package com.kwonps.data.source.user
+
+import android.content.SharedPreferences
+import com.kwonps.data.internal.dao.UserInformationDAO
+import com.kwonps.data.internal.entity.UserEntity
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Local persistence for user metadata. Cache policy: SharedPreferences keeps the last
+ * successful login payload, Room keeps user detail history. Synchronization policy:
+ * operations are scoped to caller threads; Room emits flow updates for downstream
+ * subscribers.
+ */
+class UserLocalDataSource @Inject constructor(
+    private val dao: UserInformationDAO,
+    private val sharedPreferences: SharedPreferences,
+    private val preferenceKey: String
+) {
+    fun getCurrentLoginUserInformation(): String? = sharedPreferences.getString(preferenceKey, null)
+
+    fun setCurrentLoginUserInformation(responseLoginModelString: String) {
+        sharedPreferences.edit().putString(preferenceKey, responseLoginModelString).apply()
+    }
+
+    fun insertUserInformation(userInfo: UserEntity) {
+        dao.insertUserInformation(userInfo)
+    }
+
+    fun getAllUserInformation(): Flow<List<UserEntity>> = dao.getAllUserInformation()
+
+    fun deleteUserInformation(tmnId: String) {
+        dao.deleteUserInformation(tmnId)
+    }
+}

--- a/data/src/main/java/com/kwonps/data/source/user/UserRemoteDataSource.kt
+++ b/data/src/main/java/com/kwonps/data/source/user/UserRemoteDataSource.kt
@@ -1,0 +1,22 @@
+package com.kwonps.data.source.user
+
+import com.kwonps.data.common.dispatcher.DispatcherProvider
+import com.kwonps.data.remote.DataFormat
+import com.kwonps.data.remote.apiservice.TmsAPIService
+import com.kwonps.data.remote.dto.request.RequestUser
+import com.kwonps.data.remote.dto.response.ResponseUser
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+
+/**
+ * Remote source for user login validation. No caching beyond the persistence handled by
+ * [UserLocalDataSource].
+ */
+class UserRemoteDataSource @Inject constructor(
+    private val apiService: TmsAPIService,
+    private val dispatcherProvider: DispatcherProvider
+) {
+    suspend fun validateLogin(request: RequestUser.Login): Response<ResponseUser.Login> =
+        withContext(dispatcherProvider.io) { apiService.key(DataFormat(request)) }
+}


### PR DESCRIPTION
## Summary
- refactor repositories to delegate to dedicated data sources and shared DTO-domain mappers
- introduce interceptor-based flow decorator with retry/logging and injected coroutine dispatchers
- update repository DI wiring for new components and caching documentation

## Testing
- bash gradlew :data:build *(fails: proxy HTTP/1.1 403 Forbidden while downloading Gradle)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc6c1eb1c8331bf83747fea081489)