### PR TITLE
Refactor direct payment UI state handling

### DIFF
--- a/presentation/src/main/java/com/kwonps/mtouchpos/coordinator/DirectPaymentCoordinator.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/coordinator/DirectPaymentCoordinator.kt
@@ -1,6 +1,5 @@
 package com.kwonps.mtouchpos.coordinator
 
-import androidx.compose.runtime.Composable
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
@@ -8,29 +7,19 @@ import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 import com.kwonps.mtouchpos.view.ui.navigate
 import com.kwonps.mtouchpos.vo.info.ApprovedPaymentType
-import com.kwonps.mtouchpos.vo.type.UseCaseResult
 
 class DirectPaymentCoordinator(
     override val navController: NavController
 ) : CommonCoordinator(navController) {
-    private fun ApprovedPaymentType.CompletePaymentViewInfo.navigateToCompletePaymentView() {
+    fun navigateToCompletePaymentView(completePaymentViewInfo: ApprovedPaymentType.CompletePaymentViewInfo) {
         navController.navigate(
             route = "${NavigationGraphState.CommonView.CompletePayment.name}${NavigationGraphState.DirectPaymentView.DirectPayment.name}",
             bundle = bundleOf(
-                NavigationBundleKey.RESULT_DATA to this,
+                NavigationBundleKey.RESULT_DATA to completePaymentViewInfo,
                 NavigationBundleKey.BEFORE_NAVGRAPH to navController.currentBackStackEntry!!.destination.route!!
             ),
             navOptions = NavOptions.Builder().setLaunchSingleTop(true).setPopUpTo(
                 NavigationGraphState.HomeView.Home.name, false).build()
         )
-    }
-
-    @Composable
-    fun observeResultPaymentData(
-        reactDirectPaymentInfo: UseCaseResult<ApprovedPaymentType.CompletePaymentViewInfo>
-    ) {
-        reactDirectPaymentInfo.NavigateForUseCaseResult { completePaymentViewInfo ->
-            completePaymentViewInfo.value.navigateToCompletePaymentView()
-        }
     }
 }

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/DirectPaymentView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/DirectPaymentView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -35,15 +36,21 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.window.Dialog
 import com.kwonps.mtouchpos.R
 import com.kwonps.mtouchpos.coordinator.DirectPaymentCoordinator
 import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 import com.kwonps.mtouchpos.view.ui.theme.TopNavigation
 import com.kwonps.mtouchpos.view.util.GradientButton
+import com.kwonps.mtouchpos.view.util.LoadingDialogContent
+import com.kwonps.mtouchpos.view.util.MessageDialogContent
 import com.kwonps.mtouchpos.view.util.SelectDialog
 import com.kwonps.mtouchpos.viewmodel.DirectPaymentVM
+import com.kwonps.mtouchpos.viewmodel.DirectPaymentVM.DirectPaymentState
+import com.kwonps.mtouchpos.viewmodel.DirectPaymentVM.DirectPaymentUiEvent
 import com.kwonps.mtouchpos.viewmodel.LoginVM
+import kotlinx.coroutines.flow.collectLatest
 import java.util.Calendar
 
 @Composable
@@ -68,12 +75,17 @@ fun DirectPaymentView(
 
     val currentConnectedUserInfo = mainActivityViewModel.fetchCurrentConnectedUserInfo()
     val screenWidth = LocalConfiguration.current.screenWidthDp
-    val directPaymentViewInfo = directPaymentViewModel.directPaymentInfo.collectAsStateWithLifecycle().value
+    val uiState = directPaymentViewModel.uiState.collectAsStateWithLifecycle().value
+    val directPaymentViewInfo = uiState.directPaymentInfo
 
-    DirectPaymentCoordinator(navController).observeResultPaymentData(
-        directPaymentViewModel.reactDirectPaymentInfo
-            .collectAsStateWithLifecycle().value
-    )
+    LaunchedEffect(Unit) {
+        directPaymentViewModel.uiEvent.collectLatest { event ->
+            when (event) {
+                is DirectPaymentUiEvent.NavigateToComplete -> DirectPaymentCoordinator(navController)
+                    .navigateToCompletePaymentView(event.data)
+            }
+        }
+    }
 
     Scaffold(
         topBar = { TopNavigation("수기 결제", navController) }
@@ -215,6 +227,15 @@ fun DirectPaymentView(
                 )
             }
         }
+    }
+
+    when (val paymentState = uiState.paymentState) {
+        DirectPaymentState.Loading -> Dialog(onDismissRequest = {}) { LoadingDialogContent() }
+        is DirectPaymentState.Failed -> Dialog(onDismissRequest = { directPaymentViewModel.dismissDialog() }) {
+            MessageDialogContent(paymentState.message) { directPaymentViewModel.dismissDialog() }
+        }
+
+        else -> Unit
     }
 }
 

--- a/presentation/src/main/java/com/kwonps/mtouchpos/viewmodel/DirectPaymentVM.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/viewmodel/DirectPaymentVM.kt
@@ -13,9 +13,12 @@ import com.kwonps.mtouchpos.viewmodel.mapper.toUseCaseResult
 import com.kwonps.mtouchpos.vo.info.ApprovedPaymentType
 import com.kwonps.mtouchpos.vo.type.UseCaseResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import java.util.Date
@@ -51,49 +54,65 @@ class DirectPaymentVM @Inject constructor(
         val trxId: String = "",
     )
 
-    private val _reactDirectPaymentInfo =
-        MutableStateFlow<UseCaseResult<ApprovedPaymentType.CompletePaymentViewInfo>>(UseCaseResult.Init)
-    val reactDirectPaymentInfo = _reactDirectPaymentInfo.asStateFlow()
+    data class DirectPaymentUiState(
+        val directPaymentInfo: DirectPaymentInfo = DirectPaymentInfo(),
+        val directCancelPaymentInfo: DirectCancelPaymentInfo = DirectCancelPaymentInfo(),
+        val paymentState: DirectPaymentState = DirectPaymentState.Idle
+    )
 
-    private val _directPaymentInfo = MutableStateFlow(DirectPaymentInfo())
-    val directPaymentInfo = _directPaymentInfo.asStateFlow()
+    sealed interface DirectPaymentState {
+        object Idle : DirectPaymentState
+        object Loading : DirectPaymentState
+        data class Completed(val data: ApprovedPaymentType.CompletePaymentViewInfo) : DirectPaymentState
+        data class Failed(val message: String) : DirectPaymentState
+    }
 
-    private val _directCancelPaymentInfo = MutableStateFlow(DirectCancelPaymentInfo())
-    val directCancelPaymentInfo = _directCancelPaymentInfo.asStateFlow()
+    sealed interface DirectPaymentUiEvent {
+        data class NavigateToComplete(val data: ApprovedPaymentType.CompletePaymentViewInfo) : DirectPaymentUiEvent
+    }
 
+    private val _uiState = MutableStateFlow(DirectPaymentUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<DirectPaymentUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    private fun updatePaymentState(paymentState: DirectPaymentState) {
+        _uiState.update { it.copy(paymentState = paymentState) }
+    }
 
     private fun processDirectPayment(directPaymentViewInfo: DirectPaymentInfo) {
         viewModelScope.launch {
-            _reactDirectPaymentInfo.value = UseCaseResult.Loading
+            updatePaymentState(DirectPaymentState.Loading)
             directPayment(
-                directPaymentViewInfo.toApproveDirectPaymentData()
+                directPaymentViewInfo.toApproveDirectPaymentData(),
             ).map { apiResult ->
                 apiResult.toUseCaseResult { it.toCompletePaymentInfo(fetchConnectedUserInfo()?.vat) }
             }.collect {
-                _reactDirectPaymentInfo.emit(it)
+                reducePaymentResult(it)
             }
         }
     }
 
     private fun processDirectCancelPayment(directCancelPaymentInfo: DirectCancelPaymentInfo) {
         viewModelScope.launch {
-            _reactDirectPaymentInfo.value = UseCaseResult.Loading
+            updatePaymentState(DirectPaymentState.Loading)
             directCancelPayment(
-                directCancelPaymentInfo.toCancelDirectPaymentData()
+                directCancelPaymentInfo.toCancelDirectPaymentData(),
             ).map { apiResult ->
                 apiResult.toUseCaseResult { it.toCompletePaymentInfo(fetchConnectedUserInfo()?.vat) }
             }.collect {
-                _reactDirectPaymentInfo.emit(it)
+                reducePaymentResult(it)
             }
         }
     }
 
     fun updateDirectPaymentInfo(directPaymentViewInfo: DirectPaymentInfo) {
-        _directPaymentInfo.value = directPaymentViewInfo
+        _uiState.update { it.copy(directPaymentInfo = directPaymentViewInfo) }
     }
 
     fun requestDirectPayment() {
-        processDirectPayment(directPaymentInfo.value)
+        processDirectPayment(uiState.value.directPaymentInfo)
     }
 
 
@@ -103,5 +122,26 @@ class DirectPaymentVM @Inject constructor(
 
     fun requestDirectCancelPayment(directCancelPaymentInfo: DirectCancelPaymentInfo) {
         processDirectCancelPayment(directCancelPaymentInfo)
+    }
+
+    fun dismissDialog() {
+        updatePaymentState(DirectPaymentState.Idle)
+    }
+
+    private suspend fun reducePaymentResult(result: UseCaseResult<ApprovedPaymentType.CompletePaymentViewInfo>) {
+        when (result) {
+            is UseCaseResult.Success -> {
+                updatePaymentState(DirectPaymentState.Completed(result.value))
+                _uiEvent.emit(DirectPaymentUiEvent.NavigateToComplete(result.value))
+            }
+
+            is UseCaseResult.Error -> updatePaymentState(DirectPaymentState.Failed(result.message))
+            is UseCaseResult.Exception -> updatePaymentState(
+                DirectPaymentState.Failed(result.exception.message ?: "결제 중 오류가 발생했습니다.")
+            )
+
+            is UseCaseResult.Loading -> updatePaymentState(DirectPaymentState.Loading)
+            else -> updatePaymentState(DirectPaymentState.Idle)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- consolidate direct payment UI state into a single StateFlow and event channel
- model direct payment progress with sealed classes and emit navigation events for completion
- reuse shared dialogs while simplifying the direct payment coordinator’s role

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc8f6c9e48331a24c54b92dc19cbb)