### PR TITLE
Modernize navigation handlers and offline routing

### DIFF
--- a/presentation/src/main/java/com/kwonps/mtouchpos/navigation/DirectPaymentRouter.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/navigation/DirectPaymentRouter.kt
@@ -1,0 +1,46 @@
+package com.kwonps.mtouchpos.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.core.os.bundleOf
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
+import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
+import com.kwonps.mtouchpos.vo.info.ApprovedPaymentType
+import com.kwonps.mtouchpos.vo.type.UseCaseResult
+
+class DirectPaymentRouter(
+    private val navigator: NavigationHandler
+) {
+    fun navigateToCompletePaymentView(completePaymentViewInfo: ApprovedPaymentType.CompletePaymentViewInfo) {
+        navigator.navigate(
+            route = "${NavigationGraphState.CommonView.CompletePayment.name}${NavigationGraphState.DirectPaymentView.DirectPayment.name}",
+            bundle = bundleOf(
+                NavigationBundleKey.RESULT_DATA to completePaymentViewInfo,
+                NavigationBundleKey.BEFORE_NAVGRAPH to navigator.navController.currentBackStackEntry!!.destination.route!!
+            ),
+            navOptions = NavOptions.Builder()
+                .setLaunchSingleTop(true)
+                .setPopUpTo(NavigationGraphState.HomeView.Home.name, false)
+                .build()
+        )
+    }
+
+    @Composable
+    fun observeResultPaymentData(
+        result: UseCaseResult<ApprovedPaymentType.CompletePaymentViewInfo>
+    ) {
+        navigator.run {
+            result.handleResult {
+                navigateToCompletePaymentView(it.data)
+            }
+        }
+    }
+}
+
+@Composable
+fun rememberDirectPaymentRouter(navController: NavController): DirectPaymentRouter {
+    val navigator = rememberNavigationHandler(navController)
+    return remember(navigator) { DirectPaymentRouter(navigator) }
+}

--- a/presentation/src/main/java/com/kwonps/mtouchpos/navigation/LoginRouter.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/navigation/LoginRouter.kt
@@ -1,0 +1,41 @@
+package com.kwonps.mtouchpos.navigation
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
+import com.kwonps.mtouchpos.vo.type.UseCaseResult
+
+class LoginRouter(private val navigator: NavigationHandler) {
+    private fun navigateToHome() {
+        navigator.navigate(
+            route = NavigationGraphState.HomeView.Home.name,
+            navOptions = NavOptions.Builder()
+                .setLaunchSingleTop(true)
+                .setPopUpTo(NavigationGraphState.HomeView.Home.name, false)
+                .build()
+        )
+    }
+
+    @Composable
+    fun observeResultLogin(
+        context: Context,
+        reactLogin: UseCaseResult<String>
+    ) {
+        navigator.run {
+            reactLogin.handleResult {
+                Toast.makeText(context, "로그인이 완료되었습니다", Toast.LENGTH_SHORT).show()
+                navigateToHome()
+            }
+        }
+    }
+}
+
+@Composable
+fun rememberLoginRouter(navController: NavController): LoginRouter {
+    val navigator = rememberNavigationHandler(navController)
+    return remember(navigator) { LoginRouter(navigator) }
+}

--- a/presentation/src/main/java/com/kwonps/mtouchpos/navigation/NavigationHandler.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/navigation/NavigationHandler.kt
@@ -1,0 +1,62 @@
+package com.kwonps.mtouchpos.navigation
+
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
+import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
+import com.kwonps.mtouchpos.view.ui.navigate
+import com.kwonps.mtouchpos.view.util.LoadingDialog
+import com.kwonps.mtouchpos.view.util.SelectDialog
+import com.kwonps.mtouchpos.vo.type.UseCaseResult
+
+@Stable
+class NavigationHandler(
+    val navController: NavController
+) {
+    fun navigate(
+        route: String,
+        bundle: Bundle? = null,
+        navOptions: NavOptions? = null
+    ) {
+        navController.navigate(route, bundle, navOptions)
+    }
+
+    fun showErrorDialog(message: String?) {
+        navigate(
+            route = NavigationGraphState.CommonView.MessageDialog.name,
+            bundle = Bundle().apply {
+                putParcelable(
+                    NavigationBundleKey.MESSAGE,
+                    SelectDialog(initValue = message)
+                )
+            },
+            navOptions = NavOptions.Builder().setLaunchSingleTop(true).build()
+        )
+    }
+
+    @Composable
+    fun <T> UseCaseResult<T>.handleResult(
+        onSuccess: (UseCaseResult.Success<T>) -> Unit = {}
+    ) {
+        LaunchedEffect(this) {
+            when (this@handleResult) {
+                is UseCaseResult.Success -> onSuccess(this@handleResult)
+                is UseCaseResult.Error -> showErrorDialog(this@handleResult.message)
+                is UseCaseResult.Exception -> showErrorDialog(this@handleResult.exception.message)
+                else -> {}
+            }
+        }
+
+        if (this is UseCaseResult.Loading) LoadingDialog(navController)
+    }
+}
+
+@Composable
+fun rememberNavigationHandler(navController: NavController): NavigationHandler {
+    return remember(navController) { NavigationHandler(navController) }
+}

--- a/presentation/src/main/java/com/kwonps/mtouchpos/navigation/OfflinePaymentRouter.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/navigation/OfflinePaymentRouter.kt
@@ -1,0 +1,287 @@
+package com.kwonps.mtouchpos.navigation
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.core.os.bundleOf
+import androidx.core.util.Consumer
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
+import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
+import com.kwonps.mtouchpos.view.util.SelectDialog
+import com.kwonps.mtouchpos.viewmodel.OfflinePaymentVM
+import com.kwonps.mtouchpos.vo.info.ApprovedPaymentType
+import com.kwonps.mtouchpos.vo.info.PaymentProcessState
+import com.kwonps.mtouchpos.vo.type.PurchaseType
+import java.net.URLDecoder
+
+private data class ExternalPaymentResult(
+    val isSuccess: Boolean,
+    val message: String,
+    val completePayment: ApprovedPaymentType.CompletePaymentViewInfo?
+)
+
+class OfflinePaymentRouter(
+    private val navigator: NavigationHandler,
+    private val componentActivity: ComponentActivity,
+    private val offlinePaymentViewModel: OfflinePaymentVM,
+    private val route: String,
+) {
+    private val paymentInfo get() = offlinePaymentViewModel.offlinePaymentInfo.value
+
+    fun configureIntent(
+        isSuccess: Boolean,
+        message: String,
+        merchantUrl: String,
+        paymentProcessState: PaymentProcessState.Complete? = null
+    ) {
+        val queryParameter = StringBuilder().apply {
+            append(merchantUrl)
+            append("?isSuccess=$isSuccess")
+            append("&resultMsg=$message")
+            paymentProcessState?.let {
+                append("&purchaseType=${it.data.purchaseType.code}")
+                append("&amount=${it.data.totalAmount}")
+                append("&installment=${it.data.installment}")
+                it.data.trackId?.let { trackId -> append("&trackId=${trackId}") }
+                it.data.trxId?.let { trxId -> append("&trxId=${trxId}") }
+                append("&authDate=${it.data.authDate}")
+                append("&authCode=${it.data.authCode}")
+                append("&cardNumber=${it.data.cardNumber}")
+            }
+        }.toString()
+        componentActivity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(queryParameter)))
+        componentActivity.finish()
+    }
+
+    fun navigateToDeviceDialog() {
+        navigator.navigate(
+            route = "${NavigationGraphState.CreditPaymentView.PaymentProcessDialog.name}/$route"
+        )
+    }
+
+    fun navigateToErrorDialog(message: String) {
+        navigator.navigate(
+            route = NavigationGraphState.CommonView.MessageDialog.name,
+            bundle = bundleOf(
+                NavigationBundleKey.MESSAGE to SelectDialog(
+                    initValue = message
+                )
+            ),
+            navOptions = NavOptions.Builder().setLaunchSingleTop(true).setPopUpTo(route, false).build()
+        )
+    }
+
+    @Composable
+    fun cardTerminalActivityResult() = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        handleExternalPayment(
+            isPG = offlinePaymentViewModel.offlinePaymentInfo.value.dptId == null,
+            paymentResult = parseCardReaderResult(result)
+        )
+    }
+
+    @Composable
+    fun cardTerminalNewIntent() {
+        Consumer<Intent> {
+            parseNewIntentResult(it)?.let { parsed ->
+                handleExternalPayment(
+                    isPG = offlinePaymentViewModel.offlinePaymentInfo.value.dptId == null,
+                    paymentResult = parsed
+                )
+            }
+        }.let { listener ->
+            DisposableEffect(componentActivity, navigator.navController) {
+                componentActivity.addOnNewIntentListener(listener)
+                onDispose { componentActivity.removeOnNewIntentListener(listener) }
+            }
+        }
+    }
+
+    private fun parseCardReaderResult(result: ActivityResult): ExternalPaymentResult {
+        val responseUri = result.data?.data
+        val resultMessage = when (responseUri?.getQueryParameter("response_msg")) {
+            "RDI_FAIL_MAKE_PACKET" -> "리더기 패킷 생성 오류"
+            "RDI_FAIL_READ_DATA" -> "리더기 데이터 읽기 오류"
+            "RDI_FAIL_READ_TIMEOUT" -> "리더기 타임아웃 오류"
+            "VAN_FAIL_MAKE_PACKET" -> "VAN 패킷 생성 오류"
+            "VAN_FAIL_READ_DATA" -> "VAN 데이터 읽기 오류"
+            "VAN_FAIL_READ_TIMEOUT" -> "VAN 타임아웃 오류"
+            "VAN_FAIL_SERVER_ERROR" -> "VAN 서버 오류"
+            "PAYMENT_CANCEL" -> "거래 취소"
+            "DEVICE_ROOTING" -> "루팅된 디바이스"
+            "ISNOT_DEVICE_DOWNLOAD" -> "단말기 다운로드 오류"
+            else -> "성공"
+        }
+
+        val isSuccess = responseUri?.getQueryParameter("response_code") == "0000"
+        val completePaymentViewInfo = if (isSuccess) {
+            responseUri?.let { uri ->
+                val installment = uri.getQueryParameter("installment") ?: return@let null
+                val authDate = uri.getQueryParameter("approval_date")?.trim() ?: return@let null
+                val authCode = uri.getQueryParameter("approval_no")?.trim() ?: return@let null
+                val issuer = uri.getQueryParameter("issuer_name")?.trim() ?: return@let null
+                val acquirer = uri.getQueryParameter("acquirer_name")?.trim() ?: return@let null
+                val cardNumber = uri.getQueryParameter("card_no") ?: return@let null
+                val purchaseType = if (uri.getQueryParameter("trdtype") == "F1") {
+                    PurchaseType.APPROVE
+                } else {
+                    PurchaseType.REFUND
+                }
+
+                buildCompletePaymentInfo(
+                    purchaseType = purchaseType,
+                    installment = installment,
+                    authDate = authDate,
+                    authCode = authCode,
+                    issuer = issuer,
+                    acquirer = acquirer,
+                    cardNumber = cardNumber
+                )
+            }
+        } else {
+            null
+        }
+
+        return ExternalPaymentResult(
+            isSuccess = isSuccess,
+            message = resultMessage,
+            completePayment = completePaymentViewInfo
+        )
+    }
+
+    private fun parseNewIntentResult(intent: Intent): ExternalPaymentResult? {
+        val data = intent.data ?: return null
+
+        val settleResult = data.getQueryParameter("setleSuccesAt")
+        if (settleResult != null) {
+            val isSuccess = settleResult == "O"
+            val completePaymentViewInfo = if (isSuccess) {
+                buildCompletePaymentInfo(
+                    purchaseType = if (data.getQueryParameter("delngSe") == "1") PurchaseType.APPROVE else PurchaseType.REFUND,
+                    installment = data.getQueryParameter("instlmtMonth") ?: return null,
+                    authDate = data.getQueryParameter("confmDe")?.plus(data.getQueryParameter("confmTime") ?: "") ?: return null,
+                    authCode = data.getQueryParameter("confmNo") ?: return null,
+                    issuer = data.getQueryParameter("issuCmpnyNm") ?: return null,
+                    acquirer = data.getQueryParameter("puchasCmpnyNm") ?: return null,
+                    cardNumber = data.getQueryParameter("cardNo")?.replace("-", "") ?: return null,
+                )
+            } else {
+                null
+            }
+
+            val message = URLDecoder.decode(data.getQueryParameter("setleMssage"), "UTF-8")
+            return ExternalPaymentResult(
+                isSuccess = isSuccess,
+                message = message,
+                completePayment = completePaymentViewInfo
+            )
+        }
+
+        val approvalNumber = data.getQueryParameter("approvalNo")
+        if (approvalNumber != null) {
+            val isSuccess = approvalNumber != "X"
+            val completePaymentViewInfo = if (isSuccess) {
+                buildCompletePaymentInfo(
+                    purchaseType = if (data.getQueryParameter("cancelApprovalNo") == null) PurchaseType.APPROVE else PurchaseType.REFUND,
+                    installment = data.getQueryParameter("monthVal") ?: return null,
+                    authDate = data.getQueryParameter("approvalDate")?.substring(2) ?: return null,
+                    authCode = data.getQueryParameter("approvalNo") ?: return null,
+                    issuer = data.getQueryParameter("issuerName") ?: return null,
+                    acquirer = data.getQueryParameter("acquirerName") ?: return null,
+                    cardNumber = data.getQueryParameter("cardNo")?.replace("-", "") ?: return null,
+                )
+            } else {
+                null
+            }
+
+            val message = data.getQueryParameter("message1").orEmpty()
+            return ExternalPaymentResult(
+                isSuccess = isSuccess,
+                message = message,
+                completePayment = completePaymentViewInfo
+            )
+        }
+
+        return null
+    }
+
+    private fun handleExternalPayment(
+        isPG: Boolean,
+        paymentResult: ExternalPaymentResult
+    ) {
+        val merchantUrl = paymentInfo.merchantUrl
+        val shouldReturnToMerchant = !isPG && paymentResult.completePayment != null
+
+        when {
+            paymentResult.completePayment == null -> {
+                merchantUrl?.let {
+                    configureIntent(
+                        isSuccess = false,
+                        message = paymentResult.message,
+                        merchantUrl = it
+                    )
+                } ?: navigator.showErrorDialog(paymentResult.message)
+            }
+
+            isPG -> offlinePaymentViewModel.pushOfflinePayment(paymentResult.completePayment)
+
+            shouldReturnToMerchant -> merchantUrl?.let {
+                configureIntent(
+                    isSuccess = true,
+                    message = paymentResult.message,
+                    merchantUrl = it,
+                    paymentProcessState = PaymentProcessState.Complete(paymentResult.completePayment)
+                )
+            } ?: navigator.showErrorDialog(paymentResult.message)
+        }
+    }
+
+    private fun buildCompletePaymentInfo(
+        purchaseType: PurchaseType,
+        installment: String,
+        authDate: String,
+        authCode: String,
+        issuer: String,
+        acquirer: String,
+        cardNumber: String
+    ): ApprovedPaymentType.CompletePaymentViewInfo {
+        return ApprovedPaymentType.CompletePaymentViewInfo(
+            purchaseType = purchaseType,
+            trackId = null,
+            trxId = null,
+            totalAmount = paymentInfo.totalAmount,
+            freeAmount = paymentInfo.freeAmount.toString(),
+            serviceAmount = paymentInfo.serviceAmount.toString(),
+            installment = installment,
+            authDate = authDate,
+            authCode = authCode,
+            issuer = issuer,
+            acquirer = acquirer,
+            cardNumber = cardNumber,
+            cardType = null,
+            remainAmount = null,
+        )
+    }
+}
+
+@Composable
+fun rememberOfflinePaymentRouter(
+    navController: NavController,
+    componentActivity: ComponentActivity,
+    offlinePaymentViewModel: OfflinePaymentVM,
+    route: String,
+): OfflinePaymentRouter {
+    val navigator = rememberNavigationHandler(navController)
+    return remember(navigator, componentActivity, offlinePaymentViewModel, route) {
+        OfflinePaymentRouter(navigator, componentActivity, offlinePaymentViewModel, route)
+    }
+}

--- a/presentation/src/main/java/com/kwonps/mtouchpos/navigation/PaymentHistoryRouter.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/navigation/PaymentHistoryRouter.kt
@@ -1,0 +1,33 @@
+package com.kwonps.mtouchpos.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.NavController
+import com.kwonps.mtouchpos.viewmodel.PaymentHistoryVM.PaymentStatisticInfo
+import com.kwonps.mtouchpos.viewmodel.PaymentHistoryVM.StatisticType
+import com.kwonps.mtouchpos.vo.info.ApprovedPaymentType
+import com.kwonps.mtouchpos.vo.type.UseCaseResult
+
+class PaymentHistoryRouter(
+    private val navigator: NavigationHandler
+) {
+    @Composable
+    fun observePaymentHistoryInfoList(
+        paymentHistoryViewInfo: UseCaseResult<List<ApprovedPaymentType.PaymentHistoryViewInfo>>
+    ) {
+        navigator.run { paymentHistoryViewInfo.handleResult() }
+    }
+
+    @Composable
+    fun observePaymentStatisticInfoList(
+        paymentStatisticViewInfo: UseCaseResult<HashMap<StatisticType, PaymentStatisticInfo>>
+    ) {
+        navigator.run { paymentStatisticViewInfo.handleResult() }
+    }
+}
+
+@Composable
+fun rememberPaymentHistoryRouter(navController: NavController): PaymentHistoryRouter {
+    val navigator = rememberNavigationHandler(navController)
+    return remember(navigator) { PaymentHistoryRouter(navigator) }
+}

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ExternalActivity.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ExternalActivity.kt
@@ -19,7 +19,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
-import com.kwonps.mtouchpos.coordinator.OfflinePaymentCoordinator
+import com.kwonps.mtouchpos.navigation.OfflinePaymentRouter
 import com.kwonps.mtouchpos.view.ExternalActivity.Action
 import com.kwonps.mtouchpos.view.ExternalActivity.OfflinePaymentAction
 import com.kwonps.mtouchpos.view.navgraph.CommonViewNavGraph
@@ -208,14 +208,14 @@ fun PaymentView(
     offlinePaymentViewModel: OfflinePaymentVM
 ) {
     val context = LocalContext.current as ComponentActivity
-    val offlinePaymentCoordinator = OfflinePaymentCoordinator(
+    val offlinePaymentCoordinator = OfflinePaymentRouter(
         navController = navController,
         componentActivity = context,
         offlinePaymentViewModel = offlinePaymentViewModel,
         route = route.value
     )
 
-    offlinePaymentCoordinator.CardTerminalNewIntent()
+    offlinePaymentCoordinator.cardTerminalNewIntent()
 
     LaunchedEffect(Unit) {
         val offlinePaymentInfo = when(route) {

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/CompletePayementView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/CompletePayementView.kt
@@ -26,8 +26,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.DirectPaymentCoordinator
-import com.kwonps.mtouchpos.coordinator.OfflinePaymentCoordinator
+import com.kwonps.mtouchpos.navigation.rememberDirectPaymentRouter
+import com.kwonps.mtouchpos.navigation.rememberOfflinePaymentRouter
 import com.kwonps.mtouchpos.print.CardTerminalPrintFactory
 import com.kwonps.mtouchpos.print.CardTerminalPrintManager
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
@@ -58,10 +58,10 @@ fun CompletePaymentView(
     when (argument) {
         NavigationGraphState.DirectPaymentView.DirectPayment.name -> {
             val directPaymentViewModel = hiltViewModel<DirectPaymentVM>()
+            val directPaymentRouter = rememberDirectPaymentRouter(navController)
 
-            DirectPaymentCoordinator(navController).observeResultPaymentData(
-                directPaymentViewModel.reactDirectPaymentInfo
-                    .collectAsStateWithLifecycle().value
+            directPaymentRouter.observeResultPaymentData(
+                directPaymentViewModel.reactDirectPaymentInfo.collectAsStateWithLifecycle().value
             )
 
             CompletePaymentView(navController, offlinePaymentViewModel, cardTerminalPrintManager, complete.data) {
@@ -70,14 +70,14 @@ fun CompletePaymentView(
         }
 
         NavigationGraphState.CreditPaymentView.CreditPayment.name -> {
-            val offlinePaymentCoordinator = OfflinePaymentCoordinator(
+            val offlinePaymentCoordinator = rememberOfflinePaymentRouter(
                 navController = navController,
                 offlinePaymentViewModel = offlinePaymentViewModel,
                 componentActivity = context,
                 route = argument
             )
 
-            offlinePaymentCoordinator.CardTerminalNewIntent()
+            offlinePaymentCoordinator.cardTerminalNewIntent()
 
             CompletePaymentView(navController, offlinePaymentViewModel, cardTerminalPrintManager, complete.data) {
                 offlinePaymentViewModel.updateOfflinePaymentInfo(complete.data.toCancelPaymentInfo())

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/DirectPaymentView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/DirectPaymentView.kt
@@ -38,7 +38,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
 import androidx.compose.ui.window.Dialog
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.DirectPaymentCoordinator
+import com.kwonps.mtouchpos.navigation.rememberDirectPaymentRouter
 import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 import com.kwonps.mtouchpos.view.ui.theme.TopNavigation
@@ -77,12 +77,12 @@ fun DirectPaymentView(
     val screenWidth = LocalConfiguration.current.screenWidthDp
     val uiState = directPaymentViewModel.uiState.collectAsStateWithLifecycle().value
     val directPaymentViewInfo = uiState.directPaymentInfo
+    val directPaymentRouter = rememberDirectPaymentRouter(navController)
 
     LaunchedEffect(Unit) {
         directPaymentViewModel.uiEvent.collectLatest { event ->
             when (event) {
-                is DirectPaymentUiEvent.NavigateToComplete -> DirectPaymentCoordinator(navController)
-                    .navigateToCompletePaymentView(event.data)
+                is DirectPaymentUiEvent.NavigateToComplete -> directPaymentRouter.navigateToCompletePaymentView(event.data)
             }
         }
     }

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/LoginView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/LoginView.kt
@@ -37,7 +37,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.LoginCoordinator
+import com.kwonps.mtouchpos.navigation.rememberLoginRouter
 import com.kwonps.mtouchpos.view.util.GradientButton
 import com.kwonps.mtouchpos.viewmodel.LoginVM
 import com.kwonps.mtouchpos.vo.info.UserInfo
@@ -55,10 +55,11 @@ fun PgIdLoginDialog(
     )
 
     val context = LocalContext.current
+    val loginRouter = rememberLoginRouter(navController)
     val screenWidth = LocalConfiguration.current.screenWidthDp
     val loginInfo = loginViewModel.loginInfo.collectAsStateWithLifecycle().value
 
-    LoginCoordinator(navController).ObserveResultLogin(
+    loginRouter.observeResultLogin(
         context = context,
         reactLogin = loginViewModel.reactLogin
             .collectAsStateWithLifecycle(UseCaseResult.Init).value
@@ -124,13 +125,14 @@ fun RegisteredIdDialog(
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp
     val context = LocalContext.current
+    val loginRouter = rememberLoginRouter(navController)
 
     val reactLogin = loginViewModel.reactLogin.collectAsStateWithLifecycle(UseCaseResult.Init).value
     val userInfo = loginViewModel.userInfo.collectAsStateWithLifecycle(emptyList()).value
     val loginInfo = loginViewModel.loginInfo.collectAsStateWithLifecycle().value
     var selectedIndex by remember { mutableIntStateOf(-2) }
 
-    LoginCoordinator(navController).ObserveResultLogin(
+    loginRouter.observeResultLogin(
         context = context,
         reactLogin = reactLogin
     )

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/OfflinePaymentView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/OfflinePaymentView.kt
@@ -43,7 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.OfflinePaymentCoordinator
+import com.kwonps.mtouchpos.navigation.rememberOfflinePaymentRouter
 import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 import com.kwonps.mtouchpos.view.ui.theme.TopNavigation
@@ -61,7 +61,7 @@ fun OfflinePaymentView(
     val screenWidth = LocalConfiguration.current.screenWidthDp
     val context = LocalContext.current as ComponentActivity
 
-    val offlinePaymentCoordinator = OfflinePaymentCoordinator(
+    val offlinePaymentCoordinator = rememberOfflinePaymentRouter(
         navController = navController,
         offlinePaymentViewModel = offlinePaymentViewModel,
         componentActivity = context,
@@ -71,7 +71,7 @@ fun OfflinePaymentView(
     val offlinePaymentInfo = offlinePaymentViewModel.offlinePaymentInfo
         .collectAsStateWithLifecycle().value as OfflinePaymentVM.OfflinePaymentInfo.Approve
 
-    offlinePaymentCoordinator.CardTerminalNewIntent()
+    offlinePaymentCoordinator.cardTerminalNewIntent()
 
     Scaffold(
         topBar = { TopNavigation("신용 결제", navController) }

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentHistoryDetailView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentHistoryDetailView.kt
@@ -32,7 +32,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.OfflinePaymentCoordinator
+import com.kwonps.mtouchpos.navigation.rememberOfflinePaymentRouter
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 
 import com.kwonps.mtouchpos.view.util.ColumnKeyValueTextBox
@@ -52,14 +52,14 @@ fun PaymentHistoryDetailView(
 ) {
     val context = LocalContext.current as ComponentActivity
     val screenWidth = LocalConfiguration.current.screenWidthDp
-    val offlinePaymentCoordinator = OfflinePaymentCoordinator(
+    val offlinePaymentCoordinator = rememberOfflinePaymentRouter(
         navController = navController,
         offlinePaymentViewModel = offlinePaymentViewModel,
         componentActivity = context,
         route = NavigationGraphState.PaymentHistoryView.PaymentHistoryDetail.name
     )
 
-    offlinePaymentCoordinator.CardTerminalNewIntent()
+    offlinePaymentCoordinator.cardTerminalNewIntent()
 
     Scaffold(
         topBar = {

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentHistoryView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentHistoryView.kt
@@ -46,7 +46,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.PaymentHistoryCoordinator
+import com.kwonps.mtouchpos.navigation.rememberPaymentHistoryRouter
 import com.kwonps.mtouchpos.view.navgraph.NavigationBundleKey.Companion.RESPONSE_GET_PAYMENT_LIST
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 import com.kwonps.mtouchpos.view.ui.theme.TopNavigation
@@ -107,6 +107,7 @@ fun PaymentHistoryView(
 
     val paymentPeriod = paymentHistoryViewModel.periodInfo.collectAsStateWithLifecycle().value
     val paymentHistoryInfo = paymentHistoryViewModel.paymentHistoryInfo.collectAsStateWithLifecycle(UseCaseResult.Init).value
+    val paymentHistoryRouter = rememberPaymentHistoryRouter(navController)
     val buttons = paymentHistoryViewModel.run {
         listOf(
             ButtonData("오늘") {
@@ -129,7 +130,7 @@ fun PaymentHistoryView(
 
     var selectedIndex by rememberSaveable { mutableIntStateOf(-1) }
 
-    PaymentHistoryCoordinator(navController).observePaymentHistoryInfoList(paymentHistoryInfo)
+    paymentHistoryRouter.observePaymentHistoryInfoList(paymentHistoryInfo)
 
     LaunchedEffect(Unit) {
         delay(1)

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentProcessView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentProcessView.kt
@@ -35,7 +35,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.OfflinePaymentCoordinator
+import com.kwonps.mtouchpos.navigation.OfflinePaymentRouter
+import com.kwonps.mtouchpos.navigation.rememberOfflinePaymentRouter
 import com.kwonps.mtouchpos.viewmodel.OfflinePaymentVM
 import com.kwonps.mtouchpos.viewmodel.OfflinePaymentVM.Companion.EVENT_FALLBACK
 import com.kwonps.mtouchpos.viewmodel.OfflinePaymentVM.Companion.INSERT_IC_CARD
@@ -72,7 +73,7 @@ fun PaymentProcessDialog(
     val paymentProcessState = offlinePaymentViewModel.paymentProcessState
         .collectAsStateWithLifecycle().value
     val componentActivity = findComponentActivity(LocalContext.current)
-    val offlinePaymentCoordinator = OfflinePaymentCoordinator(
+    val offlinePaymentCoordinator = rememberOfflinePaymentRouter(
         navController = navController,
         componentActivity = componentActivity,
         offlinePaymentViewModel = offlinePaymentViewModel,
@@ -175,7 +176,7 @@ fun permissionCheck(
     cardTerminalCommunicateManager: CardTerminalCommunicateManager?,
     merchantUrl: String?,
     offlinePaymentViewModel: OfflinePaymentVM,
-    offlinePaymentCoordinator: OfflinePaymentCoordinator
+    offlinePaymentCoordinator: OfflinePaymentRouter
 ) {
     val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
     var devices = usbManager.deviceList.values.toList()

--- a/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentStatisticsView.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/view/ui/PaymentStatisticsView.kt
@@ -33,7 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.kwonps.mtouchpos.R
-import com.kwonps.mtouchpos.coordinator.PaymentHistoryCoordinator
+import com.kwonps.mtouchpos.navigation.rememberPaymentHistoryRouter
 import com.kwonps.mtouchpos.view.navgraph.NavigationGraphState
 import com.kwonps.mtouchpos.view.ui.theme.TopNavigation
 import com.kwonps.mtouchpos.viewmodel.PaymentHistoryVM
@@ -55,6 +55,7 @@ fun PaymentStatisticsView(
 
     val paymentPeriod = paymentHistoryViewModel.periodInfo.collectAsStateWithLifecycle().value
     val paymentStatisticInfo = paymentHistoryViewModel.paymentStatisticInfo.collectAsStateWithLifecycle(UseCaseResult.Init).value
+    val paymentHistoryRouter = rememberPaymentHistoryRouter(navController)
     val buttons = paymentHistoryViewModel.run {
         listOf(
             ButtonData("오늘") {
@@ -77,7 +78,7 @@ fun PaymentStatisticsView(
 
     var selectedIndex by rememberSaveable { mutableIntStateOf(-1) }
 
-    PaymentHistoryCoordinator(navController).observePaymentStatisticInfoList(paymentStatisticInfo)
+    paymentHistoryRouter.observePaymentStatisticInfoList(paymentStatisticInfo)
 
     LaunchedEffect(Unit) {
         delay(1)


### PR DESCRIPTION
## Summary
- replace the navigation interface with a stable handler helper and compose-friendly result handling
- update feature routers to reuse the shared handler and keep navigation side effects scoped
- simplify offline payment routing by parsing external results through a single flow before dispatching intents or dialogs

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe5c7931c8331b1b216911645aa93)