### PR TITLE
Add parser abstraction for cached user info

### DIFF
--- a/data/src/main/java/com/kwonps/data/parser/GsonUserDetailParser.kt
+++ b/data/src/main/java/com/kwonps/data/parser/GsonUserDetailParser.kt
@@ -1,0 +1,21 @@
+package com.kwonps.data.parser
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import com.kwonps.domain.model.user.UserDetailData
+import com.kwonps.domain.parser.UserDetailParser
+import javax.inject.Inject
+
+class GsonUserDetailParser @Inject constructor(
+    private val gson: Gson = Gson()
+) : UserDetailParser {
+    override fun parse(json: String?): UserDetailData? {
+        if (json.isNullOrBlank()) return null
+
+        return try {
+            gson.fromJson(json, UserDetailData::class.java)
+        } catch (e: JsonSyntaxException) {
+            null
+        }
+    }
+}

--- a/data/src/main/java/com/kwonps/data/repositoryImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/kwonps/data/repositoryImpl/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.kwonps.data.remote.handleApiResult
 import com.kwonps.data.source.user.UserLocalDataSource
 import com.kwonps.data.source.user.UserRemoteDataSource
 import com.kwonps.domain.model.ApiResult
+import com.kwonps.domain.model.user.CachedUserInformation
 import com.kwonps.domain.model.user.UserData
 import com.kwonps.domain.model.user.UserDetailData
 import com.kwonps.domain.repository.UserRepository
@@ -24,7 +25,9 @@ class UserRepositoryImpl @Inject constructor(
     private val mapper: UserMapper,
     private val flowCallDecorator: FlowCallDecorator,
 ) : UserRepository {
-    override fun getCurrentLoginUserInformation(): String? = localDataSource.getCurrentLoginUserInformation()
+    override fun getCurrentLoginUserInformation(): CachedUserInformation =
+        localDataSource.getCurrentLoginUserInformation()?.let(CachedUserInformation::Raw)
+            ?: CachedUserInformation.Empty
 
     override fun setCurrentLoginUserInformation(responseLoginModelString: String) {
         localDataSource.setCurrentLoginUserInformation(responseLoginModelString)

--- a/domain/src/main/java/com/kwonps/domain/model/user/CachedUserInformation.kt
+++ b/domain/src/main/java/com/kwonps/domain/model/user/CachedUserInformation.kt
@@ -1,0 +1,11 @@
+package com.kwonps.domain.model.user
+
+/**
+ * Represents cached user information persisted locally. Consumers can rely on
+ * this sealed type to avoid handling nullable raw JSON strings directly.
+ */
+sealed class CachedUserInformation {
+    data class Raw(val json: String) : CachedUserInformation()
+    data class Parsed(val data: UserDetailData) : CachedUserInformation()
+    object Empty : CachedUserInformation()
+}

--- a/domain/src/main/java/com/kwonps/domain/parser/UserDetailParser.kt
+++ b/domain/src/main/java/com/kwonps/domain/parser/UserDetailParser.kt
@@ -1,0 +1,12 @@
+package com.kwonps.domain.parser
+
+import com.kwonps.domain.model.user.UserDetailData
+
+/**
+ * Abstraction for parsing user detail information. Implementations may rely on
+ * different JSON libraries or formats; callers receive null when parsing fails
+ * or the payload is absent.
+ */
+interface UserDetailParser {
+    fun parse(json: String?): UserDetailData?
+}

--- a/domain/src/main/java/com/kwonps/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/kwonps/domain/repository/UserRepository.kt
@@ -1,12 +1,13 @@
 package com.kwonps.domain.repository
 
 import com.kwonps.domain.model.ApiResult
+import com.kwonps.domain.model.user.CachedUserInformation
 import com.kwonps.domain.model.user.UserData
 import com.kwonps.domain.model.user.UserDetailData
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
-    fun getCurrentLoginUserInformation(): String?
+    fun getCurrentLoginUserInformation(): CachedUserInformation
     fun setCurrentLoginUserInformation(responseLoginModelString: String)
     fun insertUserInformation(userInfo: UserDetailData)
     fun getAllUserInformation(): Flow<List<UserDetailData>>

--- a/domain/src/main/java/com/kwonps/domain/usecase/user/FetchConnectedUserInfo.kt
+++ b/domain/src/main/java/com/kwonps/domain/usecase/user/FetchConnectedUserInfo.kt
@@ -1,16 +1,17 @@
 package com.kwonps.domain.usecase.user
 
+import com.kwonps.domain.model.user.CachedUserInformation
 import com.kwonps.domain.model.user.UserDetailData
+import com.kwonps.domain.parser.UserDetailParser
 import com.kwonps.domain.repository.UserRepository
-import com.google.gson.Gson
 
-class FetchConnectedUserInfo(private val userRepository: UserRepository) {
-    operator fun invoke(): UserDetailData? = try {
-        Gson().fromJson(
-            userRepository.getCurrentLoginUserInformation(),
-            UserDetailData::class.java
-        )
-    } catch (e: NullPointerException) {
-        null
+class FetchConnectedUserInfo(
+    private val userRepository: UserRepository,
+    private val userDetailParser: UserDetailParser
+) {
+    operator fun invoke(): UserDetailData? = when (val cachedInfo = userRepository.getCurrentLoginUserInformation()) {
+        is CachedUserInformation.Parsed -> cachedInfo.data
+        is CachedUserInformation.Raw -> userDetailParser.parse(cachedInfo.json)
+        CachedUserInformation.Empty -> null
     }
 }

--- a/presentation/src/main/java/com/kwonps/mtouchpos/di/RepositoryModule.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/di/RepositoryModule.kt
@@ -10,6 +10,7 @@ import com.kwonps.data.internal.DatabaseHelper
 import com.kwonps.data.mapper.DirectPaymentMapper
 import com.kwonps.data.mapper.PaymentHistoryMapper
 import com.kwonps.data.mapper.UserMapper
+import com.kwonps.data.parser.GsonUserDetailParser
 import com.kwonps.data.remote.RetrofitBuilder
 import com.kwonps.data.repositoryImpl.BluetoothCardReaderRepositoryImpl
 import com.kwonps.data.repositoryImpl.DeviceRepositoryImpl
@@ -24,6 +25,7 @@ import com.kwonps.data.source.user.UserLocalDataSource
 import com.kwonps.data.source.user.UserRemoteDataSource
 import com.kwonps.domain.model.cardreader.CardReaderData
 import com.kwonps.domain.model.cardreader.CardReaderStatus
+import com.kwonps.domain.parser.UserDetailParser
 import com.kwonps.domain.repository.CardReaderCommunicateRepository
 import com.kwonps.domain.repository.DeviceRepository
 import com.kwonps.domain.repository.DirectPaymentRepository
@@ -78,6 +80,10 @@ object RepositoryModule {
     @Provides
     @Singleton
     fun provideUserMapper(): UserMapper = UserMapper()
+
+    @Provides
+    @Singleton
+    fun provideUserDetailParser(): UserDetailParser = GsonUserDetailParser()
 
     @Provides
     @Singleton

--- a/presentation/src/main/java/com/kwonps/mtouchpos/di/UserUseCaseModule.kt
+++ b/presentation/src/main/java/com/kwonps/mtouchpos/di/UserUseCaseModule.kt
@@ -1,5 +1,6 @@
 package com.kwonps.mtouchpos.di
 
+import com.kwonps.domain.parser.UserDetailParser
 import com.kwonps.domain.repository.UserRepository
 import com.kwonps.domain.usecase.user.DeleteUserInfo
 import com.kwonps.domain.usecase.user.FetchConnectedUserInfo
@@ -24,8 +25,9 @@ object UserUseCaseModule {
     @Provides
     @Singleton
     fun provideFetchConnectedUserInfo(
-        userRepository: UserRepository
-    ): FetchConnectedUserInfo = FetchConnectedUserInfo(userRepository)
+        userRepository: UserRepository,
+        userDetailParser: UserDetailParser
+    ): FetchConnectedUserInfo = FetchConnectedUserInfo(userRepository, userDetailParser)
 
     @Provides
     @Singleton

--- a/presentation/src/test/java/com/kwonps/mtouchpos/fakes/FakeUserRepository.kt
+++ b/presentation/src/test/java/com/kwonps/mtouchpos/fakes/FakeUserRepository.kt
@@ -1,6 +1,7 @@
 package com.kwonps.mtouchpos.fakes
 
 import com.kwonps.domain.model.ApiResult
+import com.kwonps.domain.model.user.CachedUserInformation
 import com.kwonps.domain.model.user.UserData
 import com.kwonps.domain.model.user.UserDetailData
 import com.kwonps.domain.repository.UserRepository
@@ -10,7 +11,8 @@ import kotlinx.coroutines.flow.flowOf
 class FakeUserRepository : UserRepository {
     var currentUserJson: String? = null
 
-    override fun getCurrentLoginUserInformation(): String? = currentUserJson
+    override fun getCurrentLoginUserInformation(): CachedUserInformation =
+        currentUserJson?.let(CachedUserInformation::Raw) ?: CachedUserInformation.Empty
 
     override fun setCurrentLoginUserInformation(responseLoginModelString: String) {
         currentUserJson = responseLoginModelString

--- a/presentation/src/test/java/com/kwonps/mtouchpos/viewmodel/OfflinePaymentVMTest.kt
+++ b/presentation/src/test/java/com/kwonps/mtouchpos/viewmodel/OfflinePaymentVMTest.kt
@@ -18,6 +18,7 @@ import com.kwonps.domain.usecase.offlinePayment.ProcessOfflinePayment
 import com.kwonps.domain.usecase.offlinePayment.RequestOfflinePayment
 import com.kwonps.domain.usecase.offlinePayment.SyncReceipt
 import com.kwonps.domain.usecase.user.FetchConnectedUserInfo
+import com.kwonps.data.parser.GsonUserDetailParser
 import com.kwonps.mtouchpos.MainDispatcherRule
 import com.kwonps.mtouchpos.fakes.FakeCardReaderCommunicateRepository
 import com.kwonps.mtouchpos.fakes.FakeDeviceRepository
@@ -76,7 +77,7 @@ class OfflinePaymentVMTest {
         }
 
         val fetchConnectedDeviceInfo = FetchConnectedDeviceInfo(jsonAdapter, deviceRepository, dispatcherProvider)
-        val fetchConnectedUserInfo = FetchConnectedUserInfo(userRepository)
+        val fetchConnectedUserInfo = FetchConnectedUserInfo(userRepository, GsonUserDetailParser())
         val requestOfflinePayment = RequestOfflinePayment(offlineRepository)
         val processOfflinePayment = ProcessOfflinePayment(offlineRepository)
         val syncReceipt = SyncReceipt(offlineRepository)


### PR DESCRIPTION
## Summary
- add a reusable user detail parser interface and Gson-backed implementation
- return cached user information as a sealed type and parse it safely in FetchConnectedUserInfo
- wire parser through DI and update tests to consume typed cached user data

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303a70fe8c8331bb73071af252a865)